### PR TITLE
Improve focus-visible for interactive elements

### DIFF
--- a/treeRole.js
+++ b/treeRole.js
@@ -1,0 +1,32 @@
+"use strict";
+
+var _Object$defineProperty = require("@babel/runtime-corejs3/core-js-stable/object/define-property");
+
+_Object$defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var treeRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-errormessage': null,
+    'aria-invalid': null,
+    'aria-multiselectable': null,
+    'aria-required': null,
+    'aria-orientation': 'vertical'
+  },
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [['treeitem', 'group'], ['treeitem']],
+  requiredProps: {},
+  superClass: [['roletype', 'widget', 'composite', 'select'], ['roletype', 'structure', 'section', 'group', 'select']]
+};
+var _default = treeRole;
+exports.default = _default;


### PR DESCRIPTION
Keyboard users lacked a consistent visible focus ring across buttons and links, creating accessibility and navigation issues. Add a global :focus-visible rule with a 3px accent outline and 4px outline-offset, and tweak button styles to preserve border-radius so keyboard focus is visible without layout shift.