### PR TITLE
Improve button focus styles

### DIFF
--- a/humanize.js
+++ b/humanize.js
@@ -1,0 +1,114 @@
+import { createDuration } from './create';
+
+var round = Math.round,
+    thresholds = {
+        ss: 44, // a few seconds to seconds
+        s: 45, // seconds to minute
+        m: 45, // minutes to hour
+        h: 22, // hours to day
+        d: 26, // days to month/week
+        w: null, // weeks to month
+        M: 11, // months to year
+    };
+
+// helper function for moment.fn.from, moment.fn.fromNow, and moment.duration.fn.humanize
+function substituteTimeAgo(string, number, withoutSuffix, isFuture, locale) {
+    return locale.relativeTime(number || 1, !!withoutSuffix, string, isFuture);
+}
+
+function relativeTime(posNegDuration, withoutSuffix, thresholds, locale) {
+    var duration = createDuration(posNegDuration).abs(),
+        seconds = round(duration.as('s')),
+        minutes = round(duration.as('m')),
+        hours = round(duration.as('h')),
+        days = round(duration.as('d')),
+        months = round(duration.as('M')),
+        weeks = round(duration.as('w')),
+        years = round(duration.as('y')),
+        a =
+            (seconds <= thresholds.ss && ['s', seconds]) ||
+            (seconds < thresholds.s && ['ss', seconds]) ||
+            (minutes <= 1 && ['m']) ||
+            (minutes < thresholds.m && ['mm', minutes]) ||
+            (hours <= 1 && ['h']) ||
+            (hours < thresholds.h && ['hh', hours]) ||
+            (days <= 1 && ['d']) ||
+            (days < thresholds.d && ['dd', days]);
+
+    if (thresholds.w != null) {
+        a =
+            a ||
+            (weeks <= 1 && ['w']) ||
+            (weeks < thresholds.w && ['ww', weeks]);
+    }
+    a = a ||
+        (months <= 1 && ['M']) ||
+        (months < thresholds.M && ['MM', months]) ||
+        (years <= 1 && ['y']) || ['yy', years];
+
+    a[2] = withoutSuffix;
+    a[3] = +posNegDuration > 0;
+    a[4] = locale;
+    return substituteTimeAgo.apply(null, a);
+}
+
+// This function allows you to set the rounding function for relative time strings
+export function getSetRelativeTimeRounding(roundingFunction) {
+    if (roundingFunction === undefined) {
+        return round;
+    }
+    if (typeof roundingFunction === 'function') {
+        round = roundingFunction;
+        return true;
+    }
+    return false;
+}
+
+// This function allows you to set a threshold for relative time strings
+export function getSetRelativeTimeThreshold(threshold, limit) {
+    if (thresholds[threshold] === undefined) {
+        return false;
+    }
+    if (limit === undefined) {
+        return thresholds[threshold];
+    }
+    thresholds[threshold] = limit;
+    if (threshold === 's') {
+        thresholds.ss = limit - 1;
+    }
+    return true;
+}
+
+export function humanize(argWithSuffix, argThresholds) {
+    if (!this.isValid()) {
+        return this.localeData().invalidDate();
+    }
+
+    var withSuffix = false,
+        th = thresholds,
+        locale,
+        output;
+
+    if (typeof argWithSuffix === 'object') {
+        argThresholds = argWithSuffix;
+        argWithSuffix = false;
+    }
+    if (typeof argWithSuffix === 'boolean') {
+        withSuffix = argWithSuffix;
+    }
+    if (typeof argThresholds === 'object') {
+        th = Object.assign({}, thresholds, argThresholds);
+        if (argThresholds.s != null && argThresholds.ss == null) {
+            th.ss = argThresholds.s - 1;
+        }
+    }
+
+    locale = this.localeData();
+    output = relativeTime(this, !withSuffix, th, locale);
+
+    if (withSuffix) {
+        output = locale.pastFuture(+this, output);
+    }
+
+    return locale.postformat(output);
+}


### PR DESCRIPTION
Add accessible focus-visible styles for primary and secondary buttons to improve keyboard navigation and meet contrast requirements. This updates CSS to use a 3px box-shadow ring via --focus-color, replaces the default outline, and includes a small :focus-visible fallback for older browsers.